### PR TITLE
Fix example mesh compilation errors

### DIFF
--- a/VoxelMeshOptimizerLibrary/examples/ConsoleAppExample/ExampleMesh.cs
+++ b/VoxelMeshOptimizerLibrary/examples/ConsoleAppExample/ExampleMesh.cs
@@ -6,4 +6,5 @@ public class ExampleMesh : Mesh
 {
     public IReadOnlyList<(float x, float y, float z)> Vertices { get; init; } = new List<(float, float, float)>();
     public IReadOnlyList<int> Triangles { get; init; } = new List<int>();
+    public List<MeshQuad> Quads { get; } = new();
 }

--- a/VoxelMeshOptimizerLibrary/examples/ConsoleAppExample/Program.cs
+++ b/VoxelMeshOptimizerLibrary/examples/ConsoleAppExample/Program.cs
@@ -13,7 +13,8 @@ class Program
             { {0,0,0} , {0,0,0}, {0,0,0}},
         };
         var exampleChunk = new ExampleChunk(voxels);
-        var optimizer = new DisjointSetMeshOptimizer();
+        var mesh = new ExampleMesh();
+        var optimizer = new DisjointSetMeshOptimizer(mesh);
         Mesh optimizedMesh = optimizer.Optimize(exampleChunk);
 
         Console.WriteLine("Mesh optimized successfully!");


### PR DESCRIPTION
## Summary
- implement `Mesh.Quads` in ExampleMesh
- pass an ExampleMesh to `DisjointSetMeshOptimizer` in console example

## Testing
- `dotnet build --no-restore`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842f3815174832a8e2cbcad5977ed38